### PR TITLE
changed disable_admin_mfa test util func name to disable_mfa

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -15,7 +15,7 @@ Built in helpers
 Disabling MFA checks
 --------------------
 
-You can use the :func:`maykin_2fa.test.disable_admin_mfa` decorator/context manager to
+You can use the :func:`maykin_2fa.test.disable_mfa` decorator/context manager to
 automatically mark an authenticated user in the admin as verified. This uses the
 ``MAYKIN_2FA_ALLOW_MFA_BYPASS_BACKENDS`` setting under the hood.
 
@@ -27,10 +27,10 @@ Example:
 .. code-block:: python
 
     from django_webtest import WebTest
-    from maykin_2fa.test import disable_admin_mfa
+    from maykin_2fa.test import disable_mfa
 
 
-    @disable_admin_mfa()
+    @disable_mfa()
     class MyAdminTests(WebTest):
 
         def test_admin_index(self):

--- a/maykin_2fa/test/__init__.py
+++ b/maykin_2fa/test/__init__.py
@@ -19,9 +19,9 @@ DJANGO_WEBTEST_BACKENDS = (
 )
 
 
-def disable_admin_mfa():
+def disable_mfa():
     """
-    Test helper to disable MFA requirements in the admin.
+    Test helper to disable MFA requirements, particularly useful in the admin.
 
     Based on :func:`django.test.override_settings`, so you can use it as a decorator
     or context manager.
@@ -29,6 +29,18 @@ def disable_admin_mfa():
     django_backends = settings.AUTHENTICATION_BACKENDS
     all_backends = django_backends + list(DJANGO_WEBTEST_BACKENDS)
     return override_settings(MAYKIN_2FA_ALLOW_MFA_BYPASS_BACKENDS=all_backends)
+
+
+disable_admin_mfa = disable_mfa
+"""
+Alias for disable_mfa.
+
+This is exactly the the same as :func:`disable_mfa`, because the ``user.is_verified``
+check is added via middleware which applies to the entire project and not just
+the admin. However, this alias exists because maykin-2fa deliberately scopes
+itself to managing access to the admin interface. Use the name that best conveys
+your intent in your test cases.
+"""
 
 
 def _totp_str(key: bytes):


### PR DESCRIPTION
Changing the `disable_admin_mfa` decorator name to the more accurate  name `disable_mfa`.
