### PR TITLE
:bug: Ensure that mfa-disabled logins respect the ?next= query param

### DIFF
--- a/maykin_2fa/views.py
+++ b/maykin_2fa/views.py
@@ -46,6 +46,11 @@ class AdminLoginView(_LoginView):
 
     def get_context_data(self, form, **kwargs):
         context = super().get_context_data(form, **kwargs)
+
+        # upstream doesn't provide a value for the "next" context variable at all
+        redirect_to = self.request.GET.get(self.redirect_field_name, "")
+        context.setdefault("next", redirect_to)
+
         context.update(
             {
                 **admin.site.each_context(self.request),


### PR DESCRIPTION
Came across this while writing tests for Open Forms.

This is actually a defect in the upstream library, I can't seem to find a place where the `next` param would be provided to the template context.