### PR TITLE
Support newer django two factor auth

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -19,7 +19,7 @@ local development and/or experimenting:
 
 .. code-block:: bash
 
-    pip install -e .[tests,coverage,docs,release]
+    pip install -e .[tests,docs,release]
 
 Due to some Python path details, we also recommend setting some environment variables:
 

--- a/maykin_2fa/admin.py
+++ b/maykin_2fa/admin.py
@@ -1,9 +1,28 @@
+from django.contrib.admin import AdminSite
 from django.core.exceptions import ImproperlyConfigured
 
-from two_factor.admin import AdminSiteOTPRequired
 
+class MFARequired(AdminSite):
+    """
+    AdminSite enforcing MFA verified staff users.
 
-class MFARequired(AdminSiteOTPRequired):
+    .. warning:: This is a *copy* of two_factor.admin.AdminSiteOTPRequired, rather than
+       subclassing. As of 1.18.0, the OTPRequiredMixin forces a URL resolution to
+       ``two_factor:setup``, which is not included for our admin purposes. Using a
+       different class/instance bypasses this check.
+
+       We have our own logic that forces users to set up the MFA flow.
+    """
+
+    def has_permission(self, request):
+        """
+        Returns True if the given HttpRequest has permission to view
+        *at least one* page in the admin site.
+        """
+        if not super().has_permission(request):
+            return False
+        return request.user.is_verified()
+
     def login(self, request, extra_context=None):
         """
         Disabled to enforce usage of the custom login views.
@@ -11,4 +30,25 @@ class MFARequired(AdminSiteOTPRequired):
         raise ImproperlyConfigured(
             "Ensure the maykin_2fa urls are included *before* the default "
             "admin.site.urls."
+        )
+
+
+# sanity check that our own admin site variant overrides the same methods as the
+# AdminSiteOTPRequiredMixin does, to catch upstream changes asap.
+if __debug__:  # pragma: no cover
+    import inspect
+
+    from two_factor.admin import AdminSiteOTPRequiredMixin
+
+    upstream_methods = {
+        name
+        for name, obj in inspect.getmembers(AdminSiteOTPRequiredMixin)
+        if inspect.isfunction(obj)
+    }
+    own_methods = {
+        name for name, obj in MFARequired.__dict__.items() if inspect.isfunction(obj)
+    }
+    if not_in_both := upstream_methods ^ own_methods:
+        raise TypeError(
+            f"Implementations have mismatching set of methods. Check: {not_in_both}."
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "django>=4.2",
     # TODO: check if we want phonenumberslite or phonenumbers - we typically only
     # use OTP and/or hardware tokens so this may not be relevant at all.
-    "django-two-factor-auth[phonenumberslite,webauthn]",
+    "django-two-factor-auth[webauthn]>=1.18.1",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,13 +46,11 @@ Changelog = "https://github.com/maykinmedia/maykin-2fa/blob/main/CHANGELOG.rst"
 tests = [
     "pytest",
     "pytest-django",
+    "pytest-cov",
     "tox",
     "isort",
     "black",
     "flake8",
-]
-coverage = [
-    "pytest-cov",
 ]
 docs = [
     "sphinx",
@@ -60,7 +58,6 @@ docs = [
 ]
 release = [
     "bump-my-version",
-    "twine",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
Closes #23

Fixed the otp-required detection triggering an unexpected code path, and improved the packaging a bit.