### PR TITLE
[#5] add auth status view of current user

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -139,3 +139,16 @@ You can run ``python manage.py check`` to diagnose potential problems.
 
 We recommend putting a link in the admin user links to the
 ``maykin_2fa:account_security`` view where users can manage their backup tokens.
+
+To include the available endpoints, update your root ``urls.py`` like below:
+
+.. code-block::
+
+    urlpatterns = [
+        ...,
+        path("api/", include("maykin_2fa.api.urls")),
+        ...,
+    ]
+
+See :ref:`The API reference section <api-section>` for more information about the
+available endpoints.

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -82,3 +82,19 @@ this to:
 
 Alternatively, if you have a custom check, make sure to also check
 ``hijacker.is_verified()``.
+
+.. _api-section:
+
+API
+===
+
+Maykin 2FA provides an API endpoint that can be used to retrieve the status of
+two factor authentication for the current user. An example response of the endpoint
+can be seen below:
+
+.. code-block:: json
+
+    {"authStatus": {"mfaVerified": false}}
+
+.. automodule:: maykin_2fa.api.views
+   :members:

--- a/maykin_2fa/api/urls.py
+++ b/maykin_2fa/api/urls.py
@@ -1,0 +1,9 @@
+from django.urls import path
+
+from maykin_2fa.api.views import UserInfoView
+
+app_name = "maykin_2fa_api"
+
+urlpatterns = [
+    path("accounts/me", UserInfoView.as_view(), name="user_info"),
+]

--- a/maykin_2fa/api/views.py
+++ b/maykin_2fa/api/views.py
@@ -1,0 +1,19 @@
+from django.http import HttpRequest, JsonResponse
+from django.views.generic import View
+
+
+class UserInfoView(View):
+    """
+    Retrieve info related to the current authenticated user.
+
+    Note that this endpoint is only available to authenticated users. Unauthenticated
+    requests will receive a 401 error response.
+    """
+
+    def get(self, request: HttpRequest):
+        if not request.user.is_authenticated:
+            return JsonResponse(
+                {"error": "This endpoint requires authentication."}, status=401
+            )
+
+        return JsonResponse({"authStatus": {"mfaVerified": request.user.is_verified()}})

--- a/testapp/urls.py
+++ b/testapp/urls.py
@@ -16,4 +16,5 @@ urlpatterns = [
     path("admin/", include((urlpatterns, "maykin_2fa"))),
     path("admin/", include((webauthn_urlpatterns, "two_factor"))),
     path("admin/", admin.site.urls),
+    path("api/", include("maykin_2fa.api.urls")),
 ]

--- a/tests/test_user_info_endpoint.py
+++ b/tests/test_user_info_endpoint.py
@@ -1,0 +1,39 @@
+from django.contrib.auth.models import AbstractBaseUser
+from django.test import Client
+from django.urls import reverse
+
+import pytest
+
+
+@pytest.mark.django_db
+def test_non_authenticated_user_get(client: Client):
+    response = client.get(reverse("maykin_2fa_api:user_info"))
+
+    assert response.status_code == 401
+
+
+@pytest.mark.django_db
+def test_authenticated_user_get(client: Client, user: AbstractBaseUser):
+    client.login(username="johny", password="password")
+    response = client.get(reverse("maykin_2fa_api:user_info"))
+
+    assert response.status_code == 200
+    response_data = response.json()
+    assert response_data == {
+        "authStatus": {
+            "mfaVerified": False,
+        }
+    }
+
+
+@pytest.mark.django_db
+def test_mfa_authenticated_user_get(mfa_verified_client: Client):
+    response = mfa_verified_client.get(reverse("maykin_2fa_api:user_info"))
+
+    assert response.status_code == 200
+    response_data = response.json()
+    assert response_data == {
+        "authStatus": {
+            "mfaVerified": True,
+        }
+    }


### PR DESCRIPTION
Partly closes open-formulieren/admin-ui#2

Adds a simple view which front-end clients can interact with to retrieve the current user's authentication status.

Required for https://github.com/maykinmedia/maykin-2fa/issues/5 (which is needed for [this admin-ui issue](https://github.com/open-formulieren/admin-ui/issues/2)). This new view will be used in OF to provide the front-end with the necessary data.